### PR TITLE
Allow to use CommandResult as an iterator for destructuring

### DIFF
--- a/src/obs_package_update/util.py
+++ b/src/obs_package_update/util.py
@@ -8,7 +8,11 @@ from dataclasses import dataclass
 
 @dataclass
 class CommandResult:
-    """The result of an executed command."""
+    """The result of an executed command.
+
+    This class also works like an iterator:
+    >>> retcode, stdout, stderr = CommandResult(1, "foo", "err")
+    """
 
     #: the exit code
     exit_code: int
@@ -19,6 +23,9 @@ class CommandResult:
     #: decoded standard error
     stderr: str
 
+    def __getitem__(self, index: int):
+        return list(self.__dict__.values())[index]
+
 
 async def run_cmd(
     cmd: str,
@@ -27,7 +34,7 @@ async def run_cmd(
     timeout: Optional[Union[int, float, timedelta]] = None,
     logger: Optional[logging.Logger] = None,
 ) -> CommandResult:
-    """Simple asynchronous command shell command execution.
+    """Simple asynchronous shell command execution.
 
     Args:
         cmd: The shell command to run

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -6,7 +6,7 @@ from typing import Generic, Optional, TypeVar
 from pytest_mock import MockerFixture
 import pytest
 from obs_package_update import run_cmd
-from obs_package_update.util import retry_async_run_cmd
+from obs_package_update.util import CommandResult, retry_async_run_cmd
 
 
 @pytest.mark.asyncio
@@ -40,6 +40,19 @@ async def test_raise_on_err():
     res = await run_cmd("false", raise_on_error=False)
 
     assert res.exit_code == 1
+
+
+@pytest.mark.asyncio
+async def test_iterator_CommandResult():
+    exit_code = 42
+    stderr = "errorrrrr!"
+    stdout = "foobar"
+    cmd_res = CommandResult(exit_code=exit_code, stderr=stderr, stdout=stdout)
+
+    e, out, err = cmd_res
+    assert e == exit_code
+    assert out == stdout
+    assert err == stderr
 
 
 T = TypeVar("T")


### PR DESCRIPTION
This allows for a simpler syntax like:
```
retcode, stdout, stderr = CommandResult(1, "foo", "err")
```